### PR TITLE
elimino comentarios por falla resuelta de carga template pdf

### DIFF
--- a/backend/src/modules/reportes/services/pdf.service.ts
+++ b/backend/src/modules/reportes/services/pdf.service.ts
@@ -16,9 +16,6 @@ export class PdfService {
       'templates',
       'reporte.html',
     );
-    //dist/modules/reportes/templates/reporte.html
-    //asegurarse de copiar el archivo html al directorio dist antes de ejecutar el servidor
-    //copiarlo desde reportes/templates/reporte.html
 
     let htmlTemplate = fs.readFileSync(templatePath, 'utf8');
 


### PR DESCRIPTION
Elimino comentarios sobre falla solucionada por error en carga de templates html. 

solución relacionada con inclusión anterior en nest-cli.json 
 "compilerOptions": {
    "deleteOutDir": true,
    "assets": [{ "include": "modules/**/templates/**/*.html" }],
    "watchAssets": true
  }