### PR TITLE
Resultados front

### DIFF
--- a/backend/src/modules/reportes/controllers/reportes.controller.ts
+++ b/backend/src/modules/reportes/controllers/reportes.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Param, Res } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Param,
+  Res,
+  Query,
+  BadRequestException,
+} from '@nestjs/common';
 import { ReportesService } from '../services/reportes.service';
 import { PdfService } from '../services/pdf.service';
 import { CsvReportesService } from '../services/csv-reportes.service';
@@ -42,7 +49,11 @@ export class ReportesController {
   async generarReporteResultados(
     @Param('id') id: number,
     @Param('codigo') codigo: string,
+    @Query('tipo') tipo: string,
   ) {
+    if (tipo !== 'RESULTADOS') {
+      throw new BadRequestException('El parámetro "tipo" debe ser RESULTADOS');
+    }
     return this.reportesService.generarReporteResultados(id, codigo);
   }
 }

--- a/backend/src/modules/reportes/controllers/reportes.controller.ts
+++ b/backend/src/modules/reportes/controllers/reportes.controller.ts
@@ -24,7 +24,11 @@ export class ReportesController {
     @Param('id') id: number,
     @Param('codigo') codigo: string,
     @Res() res: Response,
+    @Query('tipo') tipo: string,
   ) {
+    if (tipo !== 'RESULTADOS') {
+      throw new BadRequestException('El parámetro "tipo" debe ser RESULTADOS');
+    }
     const datosReporte = await this.reportesService.generarReporteResultados(
       id,
       codigo,
@@ -37,7 +41,12 @@ export class ReportesController {
     @Param('id') id: number,
     @Param('codigo') codigo: string,
     @Res() res: Response,
+    @Query('tipo') tipo: string, // <-- AGREGADO
   ) {
+    if (tipo !== 'RESULTADOS') {
+      // <-- AGREGADO
+      throw new BadRequestException('El parámetro "tipo" debe ser RESULTADOS');
+    }
     const datosReporte = await this.reportesService.generarReporteResultados(
       id,
       codigo,

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
         "@primeng/themes": "^19.1.2",
+        "chart.js": "^4.4.9",
         "primeicons": "^7.0.0",
         "primeng": "^19.1.2",
         "rxjs": "~7.8.0",
@@ -3422,6 +3423,12 @@
         "tslib": "2"
       }
     },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
+    },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
@@ -6383,6 +6390,18 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
     "@primeng/themes": "^19.1.2",
+    "chart.js": "^4.4.9",
     "primeicons": "^7.0.0",
     "primeng": "^19.1.2",
     "rxjs": "~7.8.0",

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -5,6 +5,9 @@ import { CreacionEncuestaComponent } from './components/formularios/creacion-enc
 import { DashboardComponent } from './components/dashboard/dashboard.component';
 import { ResponderEncuestaComponent } from './components/responder-encuesta/responder-encuesta.component';
 import { EnlaceInvalidoComponent } from './components/enlace-invalido/enlace-invalido.component';
+import { VisualizacionResultadosComponent } from './components/resultados/visualizacion-resultados/visualizacion-resultados.component';
+import { ResultadosEncuestaComponent } from './components/resultados/resultados-encuesta/resultados-encuesta.component';
+import { ResumenEstadisticoComponent } from './components/resultados/resumen-estadistico/resumen-estadistico.component';
 
 export const routes: Routes = [
   {
@@ -35,6 +38,16 @@ export const routes: Routes = [
     path: 'responder/enlace-invalido',
     component: EnlaceInvalidoComponent,
   },
+
+  {
+    path: 'visualizacion-resultados/:id',
+    component: VisualizacionResultadosComponent,
+    children: [
+      { path: 'resultados-encuesta', component: ResultadosEncuestaComponent },
+      { path: 'resumen-estadistico', component: ResumenEstadisticoComponent },
+    ],
+  },
+
   {
     path: '**',
     redirectTo: '',

--- a/frontend/src/app/components/home/home.component.html
+++ b/frontend/src/app/components/home/home.component.html
@@ -1,26 +1,87 @@
-
+<p-toast></p-toast>
 <div class="container">
-    <div class="bienvenido">      
-      <div class="texto">
-        <div> 
-          <h1>Opina.Ar</h1>
+  <div class="bienvenido">
+    <div class="texto">
+      <div>
+        <h1>Opina.Ar</h1>
+      </div>
+      <p>
+        Cree su encuesta para saber la opinion de la sociedad en estos
+        turbulentos tiempos que corren.
+      </p>
+      <p>Confia en nosotros.....</p>
+      <div class="botones">
+        <div>
+          <p-button
+            label="Crear"
+            [style]="{
+              backgroundColor: 'var(--color-background)',
+              width: '10rem',
+              height: '2.4rem',
+            }"
+            routerLink="/crear"
+          ></p-button>
         </div>
-        <p>Cree su encuesta para saber la opinion de la sociedad en estos
-          turbulentos tiempos que corren.</p>
-        <p>Confia en nosotros.....</p>
-        <div class="botones">
-          <div>
-            <p-button label="Crear" [style]="{backgroundColor: 'var(--color-background)', width: '10rem', height: '2.4rem'}" routerLink="/crear"></p-button>
-          </div>
-          <div>
-            <p-button label="Dashboard" [style]="{backgroundColor: 'var(--color-background)', width: '10rem', height: '2.4rem'}" routerLink="/dashboard"></p-button>
-          </div>
+        <div>
+          <p-button
+            label="Dashboard"
+            [style]="{
+              backgroundColor: 'var(--color-background)',
+              width: '10rem',
+              height: '2.4rem',
+            }"
+            routerLink="/dashboard"
+          ></p-button>
+        </div>
+        <div>
+          <p-button
+            label="Resultados"
+            [style]="{
+              backgroundColor: 'var(--color-background)',
+              width: '10rem',
+              height: '2.4rem',
+            }"
+            (onClick)="abrirDialog()"
+          ></p-button>
         </div>
       </div>
     </div>
-    <div class="contenedor-imagen"> 
-      <div class="imagen">     
-        <img src="/assets/encuestas.png" alt="Imagen de encuestas">      
-      </div>     
+  </div>
+  <div class="contenedor-imagen">
+    <div class="imagen">
+      <img src="/assets/encuestas.png" alt="Imagen de encuestas" />
     </div>
+  </div>
 </div>
+
+<p-dialog
+  header="Ir a visualización de resultados"
+  [(visible)]="mostrarDialog"
+  [modal]="true"
+  [closable]="true"
+  [style]="{ width: '25rem' }"
+>
+  <div style="display: flex; flex-direction: column; gap: 1rem">
+    <span
+      >Ingresá la URL de visualización de resultados de la encuesta a
+      consultar:</span
+    >
+    <input
+      pInputText
+      [(ngModel)]="urlResultados"
+      placeholder="http://localhost:4200/visualizacion-resultados/id?codigo=...&tipo=..."
+    />
+    <button
+      pButton
+      label="Ir"
+      icon="pi pi-arrow-right"
+      (click)="irAResultados()"
+      [disabled]="!urlResultados"
+      [style]="{
+        backgroundColor: '#2e4859',
+        color: '#fff',
+      }"
+      aria-label="Ir a resultados"
+    ></button>
+  </div>
+</p-dialog>

--- a/frontend/src/app/components/home/home.component.ts
+++ b/frontend/src/app/components/home/home.component.ts
@@ -1,17 +1,82 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
+import { RouterModule, Router } from '@angular/router';
 import { CardModule } from 'primeng/card';
 import { ButtonModule } from 'primeng/button';
+import { DialogModule } from 'primeng/dialog';
+import { InputTextModule } from 'primeng/inputtext';
+import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
+import { FormsModule } from '@angular/forms';
+import { ResultadosService } from '../../services/resultados.service';
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [CommonModule, RouterModule, CardModule, ButtonModule],
+  imports: [
+    CommonModule,
+    RouterModule,
+    CardModule,
+    ButtonModule,
+    DialogModule,
+    InputTextModule,
+    FormsModule,
+    ToastModule,
+  ],
   templateUrl: './home.component.html',
   styleUrl: './home.component.css',
+  providers: [MessageService],
 })
 export class HomeComponent {
-  // Landing page
-  title = 'Bienvenido';
+  mostrarDialog = false;
+  urlResultados = '';
+  private messageService = inject(MessageService);
+  private resultadosService = inject(ResultadosService);
+
+  constructor(private router: Router) {}
+
+  abrirDialog() {
+    this.mostrarDialog = true;
+    this.urlResultados = '';
+  }
+
+  irAResultados() {
+    if (!this.urlResultados) return;
+
+    let url = this.urlResultados.trim();
+    // Solo acepta URLs completas de localhost:4200 nuestro dominio actual
+    const match = url.match(
+      /^https?:\/\/localhost:4200\/visualizacion-resultados\/(\d+)\?codigo=([^&]+)&tipo=([^&]+)/,
+    );
+    if (!match) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'URL inválida',
+        detail: 'Pegá la URL completa que recibiste de la encuesta',
+      });
+      return;
+    }
+
+    const idEncuesta = Number(match[1]);
+    const codigo = match[2];
+    const tipo = match[3];
+
+    this.resultadosService.getResultados(idEncuesta, codigo, tipo).subscribe({
+      next: () => {
+        // Si existe y es válido, redirige a la página de resultados
+        this.router.navigateByUrl(
+          `/visualizacion-resultados/${idEncuesta}?codigo=${codigo}&tipo=${tipo}`,
+        );
+        this.mostrarDialog = false;
+      },
+      error: () => {
+        // Si no existe o hubo un error, muestra un mensaje
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Encuesta no encontrada',
+          detail: 'No se encontraron resultados para la URL ingresada.',
+        });
+      },
+    });
+  }
 }

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
@@ -27,6 +27,19 @@
   gap: 0.2rem;
 }
 
+.botonera-flex {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  margin-bottom: 0.3rem;
+}
+
+.botonera-centrado {
+  font-weight: 500;
+  font-size: 1.1rem;
+}
+
 .icono-descarga-rect {
   padding-top: 1rem !important;
   min-width: 1.5rem !important;
@@ -42,11 +55,11 @@
 }
 
 .icono-descarga-rect.csv {
-  background-color: #22c55e !important; /* verde */
+  background-color: #22c55e !important;
   color: #fff !important;
 }
 .icono-descarga-rect.pdf {
-  background-color: #ef4444 !important; /* rojo */
+  background-color: #ef4444 !important;
   color: #fff !important;
 }
 
@@ -71,28 +84,6 @@
   border: 1px solid #e0e0e0;
   box-sizing: border-box;
   font-size: 0.97rem;
-}
-
-.info-encuestado {
-  margin-bottom: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.etiqueta {
-  background: #e7eff6;
-  color: #1976d2;
-  border-radius: 4px;
-  padding: 2px 7px;
-  font-size: 0.93rem;
-  font-weight: 500;
-  margin-right: 0.5rem;
-}
-
-.valor-encuestado {
-  font-weight: 500;
-  color: #222;
 }
 
 .subtitulo {
@@ -123,7 +114,7 @@
   line-height: 1.2;
 }
 
-/* Opciones en columna, sin bullets */
+/* Opciones listado */
 .opciones-lista,
 .opciones-lista-vertical {
   display: flex;
@@ -145,7 +136,7 @@
   margin-left: 0;
 }
 
-/* Respuestas abiertas: azul suave*/
+/* Respuestas abiertas*/
 .respuesta-abierta {
   margin-top: 0.12rem;
   font-size: 0.95rem;
@@ -157,7 +148,7 @@
   font-weight: 500;
 }
 
-/* Quitar bullets de listas generales */
+/* listas en general */
 ul {
   list-style-type: none;
   padding-left: 0;
@@ -179,13 +170,7 @@ ul {
   font-size: 0.98rem;
 }
 
-.botonera {
-  display: flex;
-  justify-content: center;
-  gap: 0.7rem;
-  margin: 0.7rem 0;
-}
-
+/* Media queries */
 @media (max-width: 600px) {
   .titulo-bar {
     flex-direction: column;
@@ -199,8 +184,9 @@ ul {
     padding: 0.5rem !important;
     max-width: 100vw !important;
   }
-  .botonera {
+  .botonera-flex {
     flex-direction: column;
     gap: 0.4rem;
+    margin-bottom: 0.8rem;
   }
 }

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
@@ -1,0 +1,40 @@
+.contenedor-resultados {
+  width: clamp(300px, 80vw, 800px);
+  padding: 2rem;
+  background-color: var(--color-background-light);
+  border-radius: 12px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.titulo {
+  font-size: 2rem;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.encuestado {
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin: 10px 0;
+}
+
+.bloque-opciones,
+.bloque-abiertas {
+  margin-top: 20px;
+  padding: 1rem;
+  background-color: #f0f0f0;
+  border-radius: 8px;
+}
+
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+li {
+  padding: 8px;
+  background-color: #e3e3e3;
+  border-radius: 6px;
+  margin: 5px 0;
+}

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
@@ -1,40 +1,23 @@
 .contenedor-resultados {
-  width: clamp(300px, 80vw, 800px);
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
   padding: 2rem;
-  background-color: var(--color-background-light);
+  background: #f4f8fb;
   border-radius: 12px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
 }
 
-.titulo {
-  font-size: 2rem;
-  font-weight: bold;
-  text-align: center;
-  margin-bottom: 20px;
+.p-card {
+  margin-top: 2rem;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
 }
 
-.encuestado {
-  font-size: 1.5rem;
-  font-weight: bold;
-  margin: 10px 0;
-}
-
-.bloque-opciones,
-.bloque-abiertas {
-  margin-top: 20px;
-  padding: 1rem;
-  background-color: #f0f0f0;
-  border-radius: 8px;
-}
-
-ul {
-  list-style-type: none;
-  padding: 0;
-}
-
-li {
-  padding: 8px;
-  background-color: #e3e3e3;
-  border-radius: 6px;
-  margin: 5px 0;
+:host {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.css
@@ -1,23 +1,206 @@
-.contenedor-resultados {
+.titulo-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.titulo {
+  font-size: 1.05rem;
+  font-weight: bold;
+  color: #222;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding-left: 2rem;
+}
+
+.nombre-encuesta {
+  color: #1976d2;
+  font-weight: 500;
+  margin-left: 0.5rem;
+  font-size: 1.05rem;
+}
+
+.botonera-inline {
+  display: flex;
+  gap: 0.2rem;
+}
+
+.icono-descarga-rect {
+  padding-top: 1rem !important;
+  min-width: 1.5rem !important;
+  height: 2rem !important;
+  padding: 0 0.4rem !important;
+  border-radius: 6px !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem !important;
+  border: none !important;
+  margin-left: 0.1rem;
+}
+
+.icono-descarga-rect.csv {
+  background-color: #22c55e !important; /* verde */
+  color: #fff !important;
+}
+.icono-descarga-rect.pdf {
+  background-color: #ef4444 !important; /* rojo */
+  color: #fff !important;
+}
+
+.icono-descarga-rect .pi-download {
+  margin-left: 0.3rem;
+  font-size: 1.1rem;
+}
+
+.icono-descarga-rect:hover {
+  filter: brightness(0.93);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.bloque-respuestas.compacto {
+  margin: 1rem auto 0 auto;
+  padding: 1rem 1rem 1rem 1rem;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(25, 118, 210, 0.06);
   width: 100%;
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 2rem;
+  max-width: 420px;
+  border: 1px solid #e0e0e0;
+  box-sizing: border-box;
+  font-size: 0.97rem;
+}
+
+.info-encuestado {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.etiqueta {
+  background: #e7eff6;
+  color: #1976d2;
+  border-radius: 4px;
+  padding: 2px 7px;
+  font-size: 0.93rem;
+  font-weight: 500;
+  margin-right: 0.5rem;
+}
+
+.valor-encuestado {
+  font-weight: 500;
+  color: #222;
+}
+
+.subtitulo {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1976d2;
+  margin-bottom: 0.4rem;
+  margin-top: 1rem;
+}
+
+.pregunta-bloque {
   background: #f4f8fb;
-  border-radius: 12px;
-  box-sizing: border-box;
+  border-radius: 7px;
+  margin-bottom: 0.7rem;
+  padding: 0.7rem 1rem 0.7rem 1rem;
+  box-shadow: 0 1px 3px rgba(25, 118, 210, 0.04);
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  border: 1px solid #e3e6ea;
 }
 
-.p-card {
-  margin-top: 2rem;
-  box-sizing: border-box;
-  width: 100%;
-  max-width: 100%;
+.pregunta-titulo {
+  font-weight: 500;
+  color: #1976d2;
+  margin-bottom: 0.2rem;
+  font-size: 1rem;
+  line-height: 1.2;
 }
 
-:host {
-  display: block;
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
+/* Opciones en columna, sin bullets */
+.opciones-lista,
+.opciones-lista-vertical {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  margin: 0.1rem 0 0.1rem 0;
+  padding-left: 0.5rem;
+  list-style-type: none;
+}
+
+.opcion-tag {
+  font-size: 0.95rem;
+  background: #dddede !important;
+  color: #03192f !important;
+  border-radius: 4px !important;
+  padding: 2px 9px !important;
+  font-weight: 500;
+  display: inline-block;
+  margin-left: 0;
+}
+
+/* Respuestas abiertas: azul suave*/
+.respuesta-abierta {
+  margin-top: 0.12rem;
+  font-size: 0.95rem;
+  background: #dddede !important;
+  color: #03192f !important;
+  border-radius: 4px;
+  padding: 2px 9px;
+  display: inline-block;
+  font-weight: 500;
+}
+
+/* Quitar bullets de listas generales */
+ul {
+  list-style-type: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.cargando {
+  text-align: center;
+  color: #888;
+  font-style: italic;
+  margin: 2rem 0;
+}
+
+.bloque-estadisticas {
+  padding: 1rem;
+  background-color: #e7eff6;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.98rem;
+}
+
+.botonera {
+  display: flex;
+  justify-content: center;
+  gap: 0.7rem;
+  margin: 0.7rem 0;
+}
+
+@media (max-width: 600px) {
+  .titulo-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.3rem;
+  }
+  .botonera-inline {
+    gap: 0.3rem;
+  }
+  .bloque-respuestas.compacto {
+    padding: 0.5rem !important;
+    max-width: 100vw !important;
+  }
+  .botonera {
+    flex-direction: column;
+    gap: 0.4rem;
+  }
 }

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
@@ -1,65 +1,70 @@
+<p-toast></p-toast>
 <div class="contenedor-resultados">
   <h2>Respuestas de la Encuesta</h2>
 
   <p *ngIf="!respuestas.length">Cargando datos...</p>
 
   <div *ngIf="respuestas.length > 0">
-    <div style="display: flex; align-items: center; gap: 1rem">
-      <button (click)="anterior()" [disabled]="currentIndex() === 0">
-        &lt;
-      </button>
-      <span
-        >Encuestado {{ currentIndex() + 1 }} de {{ respuestas.length }}</span
-      >
+    <div class="p-d-flex p-ai-center p-jc-center" style="gap: 1rem">
       <button
+        pButton
+        icon="pi pi-angle-left"
+        label="Anterior"
+        (click)="anterior()"
+        [disabled]="currentIndex() === 0"
+        class="p-button-rounded p-button-secondary"
+      ></button>
+      <span>
+        Encuestado {{ currentIndex() + 1 }} de {{ respuestas.length }}
+      </span>
+      <button
+        pButton
+        icon="pi pi-angle-right"
+        label="Siguiente"
         (click)="siguiente()"
         [disabled]="currentIndex() === respuestas.length - 1"
-      >
-        &gt;
-      </button>
+        class="p-button-rounded p-button-secondary"
+      ></button>
     </div>
-    <ul>
-      <li>
-        <strong>Encuestado:</strong>
-        {{ respuestas[currentIndex()]?.encuestado }}
 
-        <div *ngIf="respuestas[currentIndex()]?.respuestasOpciones?.length > 0">
+    <p-card styleClass="p-mt-3">
+      <ng-container *ngIf="respuestas[currentIndex()] as encuestado">
+        <div>
+          <strong>Encuestado:</strong>
+          <span pTag>{{ encuestado.encuestado }}</span>
+        </div>
+
+        <div *ngIf="encuestado.respuestasOpciones?.length > 0" class="p-mt-3">
           <h4>Respuestas con opción:</h4>
           <ul>
             <li
               *ngFor="
                 let pregunta of agruparRespuestasOpciones(
-                  respuestas[currentIndex()]?.respuestasOpciones
+                  encuestado.respuestasOpciones
                 )
               "
             >
               <strong>Pregunta:</strong> {{ pregunta.textoPregunta }}
-              <br />
-              <strong>Opciones seleccionadas:</strong>
               <ul>
                 <li *ngFor="let opcion of pregunta.opcionesSeleccionadas">
-                  {{ opcion }}
+                  <span pTag severity="info">{{ opcion }}</span>
                 </li>
               </ul>
             </li>
           </ul>
         </div>
 
-        <div *ngIf="respuestas[currentIndex()]?.respuestasAbiertas?.length > 0">
+        <div *ngIf="encuestado.respuestasAbiertas?.length > 0" class="p-mt-3">
           <h4>Respuestas abiertas:</h4>
           <ul>
-            <li
-              *ngFor="
-                let abierta of respuestas[currentIndex()]?.respuestasAbiertas
-              "
-            >
-              <strong>Pregunta:</strong> {{ abierta.textoPregunta }}
-              <br />
-              <strong>Respuesta:</strong> {{ abierta.textoRespuesta }}
+            <li *ngFor="let abierta of encuestado.respuestasAbiertas">
+              <strong>Pregunta:</strong> {{ abierta.textoPregunta }}<br />
+              <strong>Respuesta:</strong>
+              <span pTag severity="success">{{ abierta.textoRespuesta }}</span>
             </li>
           </ul>
         </div>
-      </li>
-    </ul>
+      </ng-container>
+    </p-card>
   </div>
 </div>

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
@@ -17,6 +17,7 @@
             (click)="descargarCSV()"
             title="Descargar CSV"
             type="button"
+            [disabled]="!respuestas.length"
           >
             <i class="pi pi-download"></i>
           </button>
@@ -27,6 +28,7 @@
             (click)="descargarPDF()"
             title="Descargar PDF"
             type="button"
+            [disabled]="!respuestas.length"
           >
             <i class="pi pi-download"></i>
           </button>
@@ -42,7 +44,7 @@
     </p>
 
     <div *ngIf="respuestas.length > 0" class="bloque-estadisticas">
-      <div class="botonera">
+      <div class="botonera-flex">
         <button
           pButton
           icon="pi pi-angle-left"
@@ -71,14 +73,9 @@
       *ngIf="respuestas.length > 0 && respuestas[currentIndex()] as encuestado"
     >
       <div class="bloque-respuestas compacto">
-        <div class="info-encuestado">
-          <span class="etiqueta">Encuestado:</span>
-          <span class="valor-encuestado" pTag>{{ encuestado.encuestado }}</span>
-        </div>
-
         <div
-          *ngIf="encuestado.respuestasOpciones?.length > 0"
           class="grupo-respuesta"
+          *ngIf="encuestado.respuestasOpciones?.length > 0"
         >
           <div class="subtitulo">Respuestas con opción:</div>
           <ul>

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
@@ -13,7 +13,7 @@
           <button
             pButton
             icon="pi pi-file-excel"
-            class="icono-descarga-rect csv"
+            class="p-button-rounded p-button-success p-button-icon-only"
             (click)="descargarCSV()"
             title="Descargar CSV"
             type="button"
@@ -23,7 +23,7 @@
           <button
             pButton
             icon="pi pi-file-pdf"
-            class="icono-descarga-rect pdf"
+            class="p-button-rounded p-button-danger p-button-icon-only"
             (click)="descargarPDF()"
             title="Descargar PDF"
             type="button"
@@ -34,7 +34,12 @@
       </div>
     </ng-template>
 
-    <p *ngIf="!respuestas.length" class="cargando">Cargando datos...</p>
+    <p *ngIf="!respuestas.length && !errorCarga" class="cargando">
+      Cargando datos...
+    </p>
+    <p *ngIf="errorCarga" class="cargando" style="color: #d32f2f">
+      No existen encuestas con el enlace de acceso cargado.
+    </p>
 
     <div *ngIf="respuestas.length > 0" class="bloque-estadisticas">
       <div class="botonera">

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
@@ -10,6 +10,7 @@
         pButton
         icon="pi pi-angle-left"
         label="Anterior"
+        title="Anterior"
         (click)="anterior()"
         [disabled]="currentIndex() === 0"
         class="p-button-rounded p-button-secondary"
@@ -21,6 +22,7 @@
         pButton
         icon="pi pi-angle-right"
         label="Siguiente"
+        title="Siguiente"
         (click)="siguiente()"
         [disabled]="currentIndex() === respuestas.length - 1"
         class="p-button-rounded p-button-secondary"

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
@@ -1,0 +1,65 @@
+<div class="contenedor-resultados">
+  <h2>Respuestas de la Encuesta</h2>
+
+  <p *ngIf="!respuestas.length">Cargando datos...</p>
+
+  <div *ngIf="respuestas.length > 0">
+    <div style="display: flex; align-items: center; gap: 1rem">
+      <button (click)="anterior()" [disabled]="currentIndex() === 0">
+        &lt;
+      </button>
+      <span
+        >Encuestado {{ currentIndex() + 1 }} de {{ respuestas.length }}</span
+      >
+      <button
+        (click)="siguiente()"
+        [disabled]="currentIndex() === respuestas.length - 1"
+      >
+        &gt;
+      </button>
+    </div>
+    <ul>
+      <li>
+        <strong>Encuestado:</strong>
+        {{ respuestas[currentIndex()]?.encuestado }}
+
+        <div *ngIf="respuestas[currentIndex()]?.respuestasOpciones?.length > 0">
+          <h4>Respuestas con opción:</h4>
+          <ul>
+            <li
+              *ngFor="
+                let pregunta of agruparRespuestasOpciones(
+                  respuestas[currentIndex()]?.respuestasOpciones
+                )
+              "
+            >
+              <strong>Pregunta:</strong> {{ pregunta.textoPregunta }}
+              <br />
+              <strong>Opciones seleccionadas:</strong>
+              <ul>
+                <li *ngFor="let opcion of pregunta.opcionesSeleccionadas">
+                  {{ opcion }}
+                </li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+
+        <div *ngIf="respuestas[currentIndex()]?.respuestasAbiertas?.length > 0">
+          <h4>Respuestas abiertas:</h4>
+          <ul>
+            <li
+              *ngFor="
+                let abierta of respuestas[currentIndex()]?.respuestasAbiertas
+              "
+            >
+              <strong>Pregunta:</strong> {{ abierta.textoPregunta }}
+              <br />
+              <strong>Respuesta:</strong> {{ abierta.textoRespuesta }}
+            </li>
+          </ul>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
@@ -1,43 +1,81 @@
 <p-toast></p-toast>
 <div class="contenedor-resultados">
-  <h2>Respuestas de la Encuesta</h2>
+  <p-card>
+    <ng-template pTemplate="header">
+      <div class="titulo-bar">
+        <span class="titulo">
+          Respuestas de la encuesta:
+          <span *ngIf="nombreEncuesta" class="nombre-encuesta">
+            {{ nombreEncuesta }}
+          </span>
+        </span>
+        <span class="botonera-inline">
+          <button
+            pButton
+            icon="pi pi-file-excel"
+            class="icono-descarga-rect csv"
+            (click)="descargarCSV()"
+            title="Descargar CSV"
+            type="button"
+          >
+            <i class="pi pi-download"></i>
+          </button>
+          <button
+            pButton
+            icon="pi pi-file-pdf"
+            class="icono-descarga-rect pdf"
+            (click)="descargarPDF()"
+            title="Descargar PDF"
+            type="button"
+          >
+            <i class="pi pi-download"></i>
+          </button>
+        </span>
+      </div>
+    </ng-template>
 
-  <p *ngIf="!respuestas.length">Cargando datos...</p>
+    <p *ngIf="!respuestas.length" class="cargando">Cargando datos...</p>
 
-  <div *ngIf="respuestas.length > 0">
-    <div class="p-d-flex p-ai-center p-jc-center" style="gap: 1rem">
-      <button
-        pButton
-        icon="pi pi-angle-left"
-        label="Anterior"
-        title="Anterior"
-        (click)="anterior()"
-        [disabled]="currentIndex() === 0"
-        class="p-button-rounded p-button-secondary"
-      ></button>
-      <span>
-        Encuestado {{ currentIndex() + 1 }} de {{ respuestas.length }}
-      </span>
-      <button
-        pButton
-        icon="pi pi-angle-right"
-        label="Siguiente"
-        title="Siguiente"
-        (click)="siguiente()"
-        [disabled]="currentIndex() === respuestas.length - 1"
-        class="p-button-rounded p-button-secondary"
-      ></button>
+    <div *ngIf="respuestas.length > 0" class="bloque-estadisticas">
+      <div class="botonera">
+        <button
+          pButton
+          icon="pi pi-angle-left"
+          label="Anterior"
+          title="Anterior"
+          (click)="anterior()"
+          [disabled]="currentIndex() === 0"
+          class="p-button-rounded p-button-secondary"
+        ></button>
+        <span class="botonera-centrado">
+          Encuestado {{ currentIndex() + 1 }} de {{ respuestas.length }}
+        </span>
+        <button
+          pButton
+          icon="pi pi-angle-right"
+          label="Siguiente"
+          title="Siguiente"
+          (click)="siguiente()"
+          [disabled]="currentIndex() === respuestas.length - 1"
+          class="p-button-rounded p-button-secondary"
+        ></button>
+      </div>
     </div>
 
-    <p-card styleClass="p-mt-3">
-      <ng-container *ngIf="respuestas[currentIndex()] as encuestado">
-        <div>
-          <strong>Encuestado:</strong>
-          <span pTag>{{ encuestado.encuestado }}</span>
+    <ng-container
+      *ngIf="respuestas.length > 0 && respuestas[currentIndex()] as encuestado"
+    >
+      <div class="bloque-respuestas compacto">
+        <div class="info-encuestado">
+          <span class="etiqueta">Encuestado:</span>
+          <span class="valor-encuestado" pTag>{{ encuestado.encuestado }}</span>
         </div>
 
-        <div *ngIf="encuestado.respuestasOpciones?.length > 0" class="p-mt-3">
-          <h4>Respuestas con opción:</h4>
+        <div
+          *ngIf="encuestado.respuestasOpciones?.length > 0"
+          class="grupo-respuesta"
+        >
+          <div class="subtitulo">Respuestas con opción:</div>
           <ul>
             <li
               *ngFor="
@@ -45,28 +83,38 @@
                   encuestado.respuestasOpciones
                 )
               "
+              class="pregunta-bloque"
             >
-              <strong>Pregunta:</strong> {{ pregunta.textoPregunta }}
-              <ul>
+              <span class="pregunta-titulo">{{ pregunta.textoPregunta }}</span>
+              <ul class="opciones-lista-vertical">
                 <li *ngFor="let opcion of pregunta.opcionesSeleccionadas">
-                  <span pTag severity="info">{{ opcion }}</span>
+                  <span class="opcion-tag" pTag severity="info">{{
+                    opcion
+                  }}</span>
                 </li>
               </ul>
             </li>
           </ul>
         </div>
 
-        <div *ngIf="encuestado.respuestasAbiertas?.length > 0" class="p-mt-3">
-          <h4>Respuestas abiertas:</h4>
+        <div
+          *ngIf="encuestado.respuestasAbiertas?.length > 0"
+          class="grupo-respuesta"
+        >
+          <div class="subtitulo">Respuestas abiertas:</div>
           <ul>
-            <li *ngFor="let abierta of encuestado.respuestasAbiertas">
-              <strong>Pregunta:</strong> {{ abierta.textoPregunta }}<br />
-              <strong>Respuesta:</strong>
-              <span pTag severity="success">{{ abierta.textoRespuesta }}</span>
+            <li
+              *ngFor="let abierta of encuestado.respuestasAbiertas"
+              class="pregunta-bloque"
+            >
+              <span class="pregunta-titulo">{{ abierta.textoPregunta }}</span>
+              <span class="respuesta-abierta" pTag severity="success">{{
+                abierta.textoRespuesta
+              }}</span>
             </li>
           </ul>
         </div>
-      </ng-container>
-    </p-card>
-  </div>
+      </div>
+    </ng-container>
+  </p-card>
 </div>

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
@@ -1,0 +1,72 @@
+import { Component, Input, OnInit, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResultadosService } from '../../../services/resultados.service';
+import { MessageService } from 'primeng/api';
+
+@Component({
+  selector: 'app-resultados-encuesta',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './resultados-encuesta.component.html',
+  styleUrl: './resultados-encuesta.component.css',
+  providers: [MessageService],
+})
+export class ResultadosEncuestaComponent implements OnInit {
+  @Input() id!: number;
+  @Input() codigo!: string;
+  respuestas: any[] = [];
+  currentIndex = signal(0); // Signal para el índice actual
+  private resultadosService = inject(ResultadosService);
+  private messageService = inject(MessageService);
+
+  ngOnInit() {
+    this.obtenerResultados();
+  }
+
+  obtenerResultados() {
+    this.resultadosService.getResultados(this.id, this.codigo).subscribe({
+      next: (data: any) => {
+        this.respuestas = Array.isArray(data.respuestas) ? data.respuestas : [];
+        this.currentIndex.set(0); // Reinicia al primer encuestado
+      },
+      error: () => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error al obtener resultados',
+        });
+      },
+    });
+  }
+
+  agruparRespuestasOpciones(respuestasOpciones: any[]) {
+    return respuestasOpciones.reduce(
+      (
+        acc: { textoPregunta: string; opcionesSeleccionadas: any[] }[],
+        opcion: any,
+      ) => {
+        const existente = acc.find(
+          (p: { textoPregunta: string; opcionesSeleccionadas: any[] }) =>
+            p.textoPregunta === opcion.textoPregunta,
+        );
+        if (existente) {
+          existente.opcionesSeleccionadas.push(opcion.opcionSeleccionada);
+        } else {
+          acc.push({
+            textoPregunta: opcion.textoPregunta,
+            opcionesSeleccionadas: [opcion.opcionSeleccionada],
+          });
+        }
+        return acc;
+      },
+      [],
+    );
+  }
+
+  anterior() {
+    if (this.currentIndex() > 0) this.currentIndex.set(this.currentIndex() - 1);
+  }
+  siguiente() {
+    if (this.currentIndex() < this.respuestas.length - 1)
+      this.currentIndex.set(this.currentIndex() + 1);
+  }
+}

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ResultadosService } from '../../../services/resultados.service';
+import { DescargaService } from '../../../services/descarga.service';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
@@ -19,8 +20,11 @@ export class ResultadosEncuestaComponent implements OnInit {
   @Input() id!: number;
   @Input() codigo!: string;
   respuestas: any[] = [];
+  nombreEncuesta = '';
   currentIndex = signal(0);
+
   private resultadosService = inject(ResultadosService);
+  private descargaService = inject(DescargaService);
   private messageService = inject(MessageService);
 
   ngOnInit() {
@@ -30,6 +34,7 @@ export class ResultadosEncuestaComponent implements OnInit {
   obtenerResultados() {
     this.resultadosService.getResultados(this.id, this.codigo).subscribe({
       next: (data: any) => {
+        this.nombreEncuesta = data.nombre ?? '';
         this.respuestas = Array.isArray(data.respuestas) ? data.respuestas : [];
         this.currentIndex.set(0);
       },
@@ -40,6 +45,31 @@ export class ResultadosEncuestaComponent implements OnInit {
         });
       },
     });
+  }
+
+  descargarCSV() {
+    console.log('Descargar CSV llamado');
+    const url = `/api/v1/encuestas/csv/${this.id}/${this.codigo}`;
+    this.descargaService.descargarArchivo(url).subscribe((blob) => {
+      this.descargarBlob(blob, 'resultados-encuesta.csv');
+    });
+  }
+
+  descargarPDF() {
+    console.log('Descargar PDF llamado');
+    const url = `/api/v1/encuestas/pdf/${this.id}/${this.codigo}`;
+    this.descargaService.descargarArchivo(url).subscribe((blob) => {
+      this.descargarBlob(blob, 'resultados-encuesta.pdf');
+    });
+  }
+
+  private descargarBlob(blob: Blob, nombreArchivo: string) {
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = nombreArchivo;
+    a.click();
+    window.URL.revokeObjectURL(url);
   }
 
   agruparRespuestasOpciones(respuestasOpciones: any[]) {

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
@@ -19,6 +19,8 @@ import { ToastModule } from 'primeng/toast';
 export class ResultadosEncuestaComponent implements OnInit {
   @Input() id!: number;
   @Input() codigo!: string;
+  @Input() tipo!: string;
+
   respuestas: any[] = [];
   nombreEncuesta = '';
   currentIndex = signal(0);
@@ -27,24 +29,34 @@ export class ResultadosEncuestaComponent implements OnInit {
   private descargaService = inject(DescargaService);
   private messageService = inject(MessageService);
 
+  errorCarga = false;
+
   ngOnInit() {
     this.obtenerResultados();
   }
 
   obtenerResultados() {
-    this.resultadosService.getResultados(this.id, this.codigo).subscribe({
-      next: (data: any) => {
-        this.nombreEncuesta = data.nombre ?? '';
-        this.respuestas = Array.isArray(data.respuestas) ? data.respuestas : [];
-        this.currentIndex.set(0);
-      },
-      error: () => {
-        this.messageService.add({
-          severity: 'error',
-          summary: 'Error al obtener resultados',
-        });
-      },
-    });
+    this.errorCarga = false;
+    this.resultadosService
+      .getResultados(this.id, this.codigo, this.tipo)
+      .subscribe({
+        next: (data: any) => {
+          this.nombreEncuesta = data.nombre ?? '';
+          this.respuestas = Array.isArray(data.respuestas)
+            ? data.respuestas
+            : [];
+          this.currentIndex.set(0);
+          this.errorCarga = false;
+        },
+        error: () => {
+          this.respuestas = [];
+          this.errorCarga = true;
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error al obtener resultados',
+          });
+        },
+      });
   }
 
   descargarCSV() {

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
@@ -2,11 +2,15 @@ import { Component, Input, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ResultadosService } from '../../../services/resultados.service';
 import { MessageService } from 'primeng/api';
+import { ButtonModule } from 'primeng/button';
+import { CardModule } from 'primeng/card';
+import { TagModule } from 'primeng/tag';
+import { ToastModule } from 'primeng/toast';
 
 @Component({
   selector: 'app-resultados-encuesta',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, ButtonModule, CardModule, TagModule, ToastModule],
   templateUrl: './resultados-encuesta.component.html',
   styleUrl: './resultados-encuesta.component.css',
   providers: [MessageService],
@@ -15,7 +19,7 @@ export class ResultadosEncuestaComponent implements OnInit {
   @Input() id!: number;
   @Input() codigo!: string;
   respuestas: any[] = [];
-  currentIndex = signal(0); // Signal para el índice actual
+  currentIndex = signal(0);
   private resultadosService = inject(ResultadosService);
   private messageService = inject(MessageService);
 
@@ -27,7 +31,7 @@ export class ResultadosEncuestaComponent implements OnInit {
     this.resultadosService.getResultados(this.id, this.codigo).subscribe({
       next: (data: any) => {
         this.respuestas = Array.isArray(data.respuestas) ? data.respuestas : [];
-        this.currentIndex.set(0); // Reinicia al primer encuestado
+        this.currentIndex.set(0);
       },
       error: () => {
         this.messageService.add({

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
@@ -1,9 +1,18 @@
+:host {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
 .contenedor-resumen {
-  width: clamp(300px, 80vw, 800px);
+  width: 100%;
+  max-width: 100%;
+  margin: 0 auto;
   padding: 2rem;
-  background-color: var(--color-background-light);
+  background: #f4f8fb;
   border-radius: 12px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
 }
 
 .titulo {
@@ -29,4 +38,17 @@ li {
   background-color: #e3e3e3;
   border-radius: 6px;
   margin: 5px 0;
+  word-break: break-word;
+}
+
+.p-card {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  margin-bottom: 1.5rem;
+}
+
+.p-chart {
+  display: block;
+  margin: 0 auto 1rem auto;
 }

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
@@ -26,11 +26,19 @@
   padding: 1.5rem;
   background-color: #f0f0f0;
   border-radius: 8px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  overflow-x: auto;
 }
 
 ul {
   list-style-type: none;
   padding: 0;
+  margin: 0;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 li {
@@ -39,6 +47,9 @@ li {
   border-radius: 6px;
   margin: 5px 0;
   word-break: break-word;
+  white-space: normal;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .p-card {
@@ -46,9 +57,64 @@ li {
   max-width: 100%;
   box-sizing: border-box;
   margin-bottom: 1.5rem;
+  overflow-x: auto;
 }
 
-.p-chart {
+/* Wrapper para gráfico y leyenda en línea */
+.opciones-grafico-wrapper {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Estilos específicos para el gráfico de torta con clase personalizada */
+:host ::ng-deep .grafico-torta {
   display: block;
   margin: 0 auto 1rem auto;
+  width: 234px !important; /* 30% más grande que 180px */
+  height: 234px !important;
+  max-width: 280px;
+  min-width: 140px;
+}
+
+:host ::ng-deep .grafico-torta canvas {
+  width: 100% !important;
+  height: 100% !important;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+}
+
+/* Mejora la visualización en mobile */
+@media (max-width: 600px) {
+  .contenedor-resumen,
+  .bloque-estadisticas,
+  .p-card {
+    padding: 0.5rem !important;
+    width: 100% !important;
+    max-width: 100vw !important;
+    box-sizing: border-box;
+    overflow-x: auto;
+  }
+  ul,
+  li {
+    word-break: break-word;
+    white-space: normal;
+  }
+  .opciones-grafico-wrapper {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+  :host ::ng-deep .grafico-torta,
+  :host ::ng-deep .grafico-torta canvas {
+    max-width: 100vw;
+    min-width: 80px;
+    max-height: 150px;
+    height: 150px !important;
+  }
 }

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
@@ -1,8 +1,5 @@
 :host {
   display: block;
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
 }
 
 .contenedor-resumen {
@@ -15,11 +12,38 @@
   box-sizing: border-box;
 }
 
+.header-flex {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .titulo {
-  font-size: 1.2rem;
+  font-size: 1.05rem;
   font-weight: bold;
-  text-align: center;
-  margin-bottom: 1.2rem;
+  color: #222;
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding-left: 2rem;
+}
+
+.nombre-encuesta {
+  font-weight: 400;
+  color: #1976d2;
+  margin-left: 0.5rem;
+}
+
+.botonera-descarga {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.botonera-descarga .p-button {
+  min-width: 44px;
+  font-size: 1.1rem;
+  padding: 0.4rem 0.8rem;
 }
 
 .bloque-estadisticas {
@@ -27,118 +51,71 @@
   background-color: #f0f0f0;
   border-radius: 8px;
   width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  overflow-x: auto;
-}
-
-ul {
-  list-style-type: none;
-  padding: 0;
-  margin: 0;
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-}
-
-li {
-  padding: 8px;
-  background-color: #e3e3e3;
-  border-radius: 6px;
-  margin: 5px 0;
-  word-break: break-word;
-  white-space: normal;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.p-card {
-  width: 100%;
-  max-width: 100%;
-  box-sizing: border-box;
-  margin-bottom: 1.5rem;
-  overflow-x: auto;
-}
-
-/* Wrapper para gráfico y leyenda en línea */
-.opciones-grafico-wrapper {
-  display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 1.5rem;
-  flex-wrap: wrap;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-/* Estilos específicos para el gráfico de torta con clase personalizada */
-:host ::ng-deep .grafico-torta {
-  display: block;
-  margin: 0 auto 1rem auto;
-  width: 234px !important; /* 30% más grande que 180px */
-  height: 234px !important;
-  max-width: 280px;
-  min-width: 140px;
-}
-
-:host ::ng-deep .grafico-torta canvas {
-  width: 100% !important;
-  height: 100% !important;
-  background: #fff;
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
-}
-
-/* Mejora la visualización en mobile */
-@media (max-width: 600px) {
-  .contenedor-resumen,
-  .bloque-estadisticas,
-  .p-card {
-    padding: 0.5rem !important;
-    width: 100% !important;
-    max-width: 100vw !important;
-    box-sizing: border-box;
-    overflow-x: auto;
-  }
-  ul,
-  li {
-    word-break: break-word;
-    white-space: normal;
-  }
-  .opciones-grafico-wrapper {
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-  }
-  :host ::ng-deep .grafico-torta,
-  :host ::ng-deep .grafico-torta canvas {
-    max-width: 100vw;
-    min-width: 80px;
-    max-height: 150px;
-    height: 150px !important;
-  }
-}
-
-.bloque-estadisticas {
-  padding: 0.3rem;
-  background-color: #e7eff6;
-  border-radius: 8px;
-  margin-bottom: 0.3rem;
-  font-size: 0.4rem;
+  margin-bottom: 1.2rem;
 }
 
 .totales {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.4rem; /* Ajusta el valor para más o menos separación */
+  gap: 0.4rem;
   justify-content: center;
   font-size: 0.9rem;
   color: #333;
 }
 
-/*botoenra ubicación*/
+.botonera-navegacion {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
 
 .botonera-navegacion > span {
   font-size: 0.9rem;
   font-weight: 500;
+}
+
+.bloque-pregunta {
+  margin-top: 1.5rem;
+  padding: 1.2rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
+}
+
+.opciones-grafico-wrapper {
+  display: flex;
+  gap: 2rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.grafico-torta {
+  min-width: 200px;
+  max-width: 240px;
+  margin-bottom: 1rem;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+li {
+  margin-bottom: 0.5rem;
+}
+
+.total-abiertas {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  color: #1976d2;
+}
+
+.cargando {
+  color: #d32f2f;
+  font-weight: 500;
+  text-align: center;
+  margin: 2rem 0;
 }

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
@@ -47,11 +47,11 @@
 }
 
 .bloque-estadisticas {
-  padding: 1.5rem;
+  padding: 0.3rem;
   background-color: #f0f0f0;
   border-radius: 8px;
   width: 100%;
-  margin-bottom: 1.2rem;
+  margin-bottom: 0.3rem;
 }
 
 .totales {
@@ -87,7 +87,8 @@
 .opciones-grafico-wrapper {
   display: flex;
   gap: 2rem;
-  align-items: flex-start;
+  align-items: center;
+  justify-content: center;
   flex-wrap: wrap;
 }
 

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
@@ -9,17 +9,17 @@
   width: 100%;
   max-width: 100%;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 1rem;
   background: #f4f8fb;
   border-radius: 12px;
   box-sizing: border-box;
 }
 
 .titulo {
-  font-size: 2rem;
+  font-size: 1.2rem;
   font-weight: bold;
   text-align: center;
-  margin-bottom: 20px;
+  margin-bottom: 1.2rem;
 }
 
 .bloque-estadisticas {
@@ -117,4 +117,28 @@ li {
     max-height: 150px;
     height: 150px !important;
   }
+}
+
+.bloque-estadisticas {
+  padding: 0.3rem;
+  background-color: #e7eff6;
+  border-radius: 8px;
+  margin-bottom: 0.3rem;
+  font-size: 0.4rem;
+}
+
+.totales {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem; /* Ajusta el valor para más o menos separación */
+  justify-content: center;
+  font-size: 0.9rem;
+  color: #333;
+}
+
+/*botoenra ubicación*/
+
+.botonera-navegacion > span {
+  font-size: 0.9rem;
+  font-weight: 500;
 }

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.css
@@ -1,0 +1,32 @@
+.contenedor-resumen {
+  width: clamp(300px, 80vw, 800px);
+  padding: 2rem;
+  background-color: var(--color-background-light);
+  border-radius: 12px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+.titulo {
+  font-size: 2rem;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+.bloque-estadisticas {
+  padding: 1.5rem;
+  background-color: #f0f0f0;
+  border-radius: 8px;
+}
+
+ul {
+  list-style-type: none;
+  padding: 0;
+}
+
+li {
+  padding: 8px;
+  background-color: #e3e3e3;
+  border-radius: 6px;
+  margin: 5px 0;
+}

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
@@ -56,9 +56,9 @@
           <div *ngIf="(resultado.opciones?.length ?? 0) > 0">
             <h4>Opciones seleccionadas:</h4>
             <p-chart
+              class="grafico-torta"
               type="pie"
               [data]="getPieChartData(resultado)"
-              [style]="{ width: '350px', height: '350px', margin: '0 auto' }"
             ></p-chart>
             <ul>
               <li *ngFor="let opcion of resultado.opciones ?? []">

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
@@ -2,19 +2,39 @@
 <div class="contenedor-resumen">
   <p-card>
     <ng-template pTemplate="header">
-      <h2 class="titulo">Resumen Estadístico</h2>
+      <h3 class="titulo">
+        Estadísticas de la encuesta:
+        <span *ngIf="resumen['nombreEncuesta']" class="nombre-encuesta">
+          {{ resumen['nombreEncuesta'] }}
+        </span>
+      </h3>
     </ng-template>
 
-    <p *ngIf="!resumen || resumen.resultadosProcesados?.length === 0">
-      Cargando datos...
-    </p>
-
+    <!-- Sección general totales -->
     <div
-      *ngIf="(resumen?.resultadosProcesados?.length ?? 0) > 0"
+      *ngIf="resumen.cantidadEncuestasProcesadas"
       class="bloque-estadisticas"
     >
-      <!-- Botonera de navegación -->
-      <div class="p-d-flex p-ai-center p-jc-center botonera-navegacion">
+      <div class="totales">
+        <span>
+          <b>Encuestas procesadas:</b>
+          {{ resumen.cantidadEncuestasProcesadas }}
+        </span>
+        <span><b>Total de preguntas:</b> {{ resumen.totalPreguntas }}</span>
+        <span>
+          <b>Total de respuestas:</b>
+          {{ resumen.totalRespuestasAnalizadas }}
+        </span>
+      </div>
+    </div>
+
+    <!-- Navegación entre preguntas -->
+    <div
+      *ngIf="resumen.resultadosProcesados?.length > 0"
+      class="bloque-estadisticas"
+      style="margin-top: 1.5rem"
+    >
+      <div class="botonera-navegacion">
         <button
           pButton
           icon="pi pi-angle-left"
@@ -40,46 +60,111 @@
           class="p-button-rounded p-button-secondary"
         ></button>
       </div>
+    </div>
 
-      <ng-container
-        *ngIf="resumen.resultadosProcesados[currentIndex()] as resultado"
-      >
-        <p-card class="p-mb-3">
-          <ng-template pTemplate="header">
-            <h3>{{ resultado.textoPregunta }}</h3>
-          </ng-template>
-          <p>
-            Tipo:
-            <span pTag severity="warning">{{ resultado.tipoPregunta }}</span>
-          </p>
-
-          <div *ngIf="(resultado.opciones?.length ?? 0) > 0">
-            <h4>Opciones seleccionadas:</h4>
-            <p-chart
-              class="grafico-torta"
-              type="pie"
-              [data]="getPieChartData(resultado)"
-            ></p-chart>
-            <ul>
-              <li *ngFor="let opcion of resultado.opciones ?? []">
-                <span pTag severity="info">{{ opcion.textoOpcion }}</span>
-                : {{ opcion.cantidadVecesSeleccionada }} veces ({{
-                  opcion.porcentajeSeleccion
-                }})
-              </li>
-            </ul>
+    <!-- Detalle de la pregunta actual -->
+    <ng-container *ngIf="resumen.resultadosProcesados?.length > 0">
+      <div class="bloque-pregunta">
+        <h4>
+          {{ resumen.resultadosProcesados[currentIndex()]?.textoPregunta }}
+        </h4>
+        <ng-container
+          [ngSwitch]="
+            resumen.resultadosProcesados[currentIndex()]?.tipoPregunta
+          "
+        >
+          <!-- Opción múltiple simple o múltiple -->
+          <div *ngSwitchCase="'OPCION_MULTIPLE_SELECCION_SIMPLE'">
+            <div class="opciones-grafico-wrapper">
+              <div class="grafico-torta">
+                <p-chart
+                  type="pie"
+                  [data]="
+                    getPieChartData(
+                      resumen.resultadosProcesados[currentIndex()]
+                    )
+                  "
+                  [responsive]="true"
+                  [style]="{
+                    width: '100%',
+                    maxWidth: '234px',
+                    margin: '0 auto',
+                  }"
+                ></p-chart>
+              </div>
+              <ul>
+                <li
+                  *ngFor="
+                    let opcion of resumen.resultadosProcesados[currentIndex()]
+                      ?.opciones
+                  "
+                >
+                  <span pTag severity="info">{{ opcion.textoOpcion }}</span>
+                  <span style="margin-left: 1rem">
+                    {{ opcion.cantidadVecesSeleccionada }} respuestas ({{
+                      opcion.porcentajeSeleccion
+                    }})
+                  </span>
+                </li>
+              </ul>
+            </div>
           </div>
-
-          <div *ngIf="(resultado.respuestas?.length ?? 0) > 0">
-            <h4>Respuestas abiertas:</h4>
+          <div *ngSwitchCase="'OPCION_MULTIPLE_SELECCION_MULTIPLE'">
+            <div class="opciones-grafico-wrapper">
+              <div class="grafico-torta">
+                <p-chart
+                  type="pie"
+                  [data]="
+                    getPieChartData(
+                      resumen.resultadosProcesados[currentIndex()]
+                    )
+                  "
+                  [responsive]="true"
+                  [style]="{
+                    width: '100%',
+                    maxWidth: '234px',
+                    margin: '0 auto',
+                  }"
+                ></p-chart>
+              </div>
+              <ul>
+                <li
+                  *ngFor="
+                    let opcion of resumen.resultadosProcesados[currentIndex()]
+                      ?.opciones
+                  "
+                >
+                  <span pTag severity="info">{{ opcion.textoOpcion }}</span>
+                  <span style="margin-left: 1rem">
+                    {{ opcion.cantidadVecesSeleccionada }} respuestas ({{
+                      opcion.porcentajeSeleccion
+                    }})
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
+          <!-- Abierta -->
+          <div *ngSwitchCase="'ABIERTA'">
+            <div class="total-abiertas">
+              <b>Total de respuestas:</b>
+              {{
+                resumen.resultadosProcesados[currentIndex()]?.totalRespuestas
+              }}
+            </div>
             <ul>
-              <li *ngFor="let respuesta of resultado.respuestas ?? []">
+              <li
+                *ngFor="
+                  let respuesta of resumen.resultadosProcesados[currentIndex()]
+                    ?.respuestas
+                "
+              >
                 <span pTag severity="success">{{ respuesta }}</span>
               </li>
             </ul>
           </div>
-        </p-card>
-      </ng-container>
-    </div>
+        </ng-container>
+      </div>
+    </ng-container>
   </p-card>
 </div>

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
@@ -2,12 +2,36 @@
 <div class="contenedor-resumen">
   <p-card>
     <ng-template pTemplate="header">
-      <h3 class="titulo">
-        Estadísticas de la encuesta:
-        <span *ngIf="resumen['nombreEncuesta']" class="nombre-encuesta">
-          {{ resumen['nombreEncuesta'] }}
+      <div class="header-flex">
+        <span class="titulo">
+          Estadísticas de la encuesta:
+          <span *ngIf="resumen['nombreEncuesta']" class="nombre-encuesta">
+            {{ resumen['nombreEncuesta'] }}
+          </span>
         </span>
-      </h3>
+        <div class="botonera-descarga">
+          <button
+            pButton
+            type="button"
+            icon="pi pi-file-excel"
+            class="p-button-rounded p-button-success p-button-icon-only"
+            (click)="descargarCSV()"
+            title="Descargar estadísticas en CSV"
+          >
+            <i class="pi pi-download"></i>
+          </button>
+          <button
+            pButton
+            type="button"
+            icon="pi pi-file-pdf"
+            class="p-button-rounded p-button-danger p-button-icon-only"
+            (click)="descargarPDF()"
+            title="Descargar estadísticas en PDF"
+          >
+            <i class="pi pi-download"></i>
+          </button>
+        </div>
+      </div>
     </ng-template>
 
     <!-- Sección general totales -->

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
@@ -1,45 +1,86 @@
+<p-toast></p-toast>
 <div class="contenedor-resumen">
-  <h2 class="titulo">Resumen Estadístico</h2>
+  <p-card>
+    <ng-template pTemplate="header">
+      <h2 class="titulo">Resumen Estadístico</h2>
+    </ng-template>
 
-  <p *ngIf="!resumen || resumen.resultadosProcesados?.length === 0">
-    Cargando datos...
-  </p>
+    <p *ngIf="!resumen || resumen.resultadosProcesados?.length === 0">
+      Cargando datos...
+    </p>
 
-  <div
-    *ngIf="(resumen?.resultadosProcesados?.length ?? 0) > 0"
-    class="bloque-estadisticas"
-  >
-    <h3>Cantidad de encuestados: {{ resumen.cantidadEncuestasProcesadas }}</h3>
-    <h3>Total de preguntas analizadas: {{ resumen.totalPreguntas }}</h3>
-    <h3>
-      Total de respuestas analizadas: {{ resumen.totalRespuestasAnalizadas }}
-    </h3>
-
-    <h4>Resultados por pregunta:</h4>
-    <div *ngFor="let resultado of resumen.resultadosProcesados ?? []">
-      <h3>{{ resultado.textoPregunta }}</h3>
-      <p>Tipo: {{ resultado.tipoPregunta }}</p>
-
-      <div *ngIf="(resultado.opciones?.length ?? 0) > 0">
-        <h4>Opciones seleccionadas:</h4>
-        <ul>
-          <li *ngFor="let opcion of resultado.opciones ?? []">
-            <strong>{{ opcion.textoOpcion }}</strong
-            >: {{ opcion.cantidadVecesSeleccionada }} veces ({{
-              opcion.porcentajeSeleccion
-            }})
-          </li>
-        </ul>
+    <div
+      *ngIf="(resumen?.resultadosProcesados?.length ?? 0) > 0"
+      class="bloque-estadisticas"
+    >
+      <!-- Botonera de navegación -->
+      <div
+        class="p-d-flex p-ai-center p-jc-center"
+        style="gap: 1rem; margin-bottom: 1.5rem"
+      >
+        <button
+          pButton
+          icon="pi pi-angle-left"
+          label="Anterior"
+          (click)="anterior()"
+          [disabled]="currentIndex() === 0"
+          class="p-button-rounded p-button-secondary"
+        ></button>
+        <span>
+          Pregunta {{ currentIndex() + 1 }} de
+          {{ resumen.resultadosProcesados.length }}
+        </span>
+        <button
+          pButton
+          icon="pi pi-angle-right"
+          label="Siguiente"
+          (click)="siguiente()"
+          [disabled]="
+            currentIndex() === resumen.resultadosProcesados.length - 1
+          "
+          class="p-button-rounded p-button-secondary"
+        ></button>
       </div>
 
-      <div *ngIf="(resultado.respuestas?.length ?? 0) > 0">
-        <h4>Respuestas abiertas:</h4>
-        <ul>
-          <li *ngFor="let respuesta of resultado.respuestas ?? []">
-            {{ respuesta }}
-          </li>
-        </ul>
-      </div>
+      <ng-container
+        *ngIf="resumen.resultadosProcesados[currentIndex()] as resultado"
+      >
+        <p-card class="p-mb-3">
+          <ng-template pTemplate="header">
+            <h3>{{ resultado.textoPregunta }}</h3>
+          </ng-template>
+          <p>
+            Tipo:
+            <span pTag severity="warning">{{ resultado.tipoPregunta }}</span>
+          </p>
+
+          <div *ngIf="(resultado.opciones?.length ?? 0) > 0">
+            <h4>Opciones seleccionadas:</h4>
+            <p-chart
+              type="pie"
+              [data]="getPieChartData(resultado)"
+              [style]="{ width: '350px', height: '350px', margin: '0 auto' }"
+            ></p-chart>
+            <ul>
+              <li *ngFor="let opcion of resultado.opciones ?? []">
+                <span pTag severity="info">{{ opcion.textoOpcion }}</span>
+                : {{ opcion.cantidadVecesSeleccionada }} veces ({{
+                  opcion.porcentajeSeleccion
+                }})
+              </li>
+            </ul>
+          </div>
+
+          <div *ngIf="(resultado.respuestas?.length ?? 0) > 0">
+            <h4>Respuestas abiertas:</h4>
+            <ul>
+              <li *ngFor="let respuesta of resultado.respuestas ?? []">
+                <span pTag severity="success">{{ respuesta }}</span>
+              </li>
+            </ul>
+          </div>
+        </p-card>
+      </ng-container>
     </div>
-  </div>
+  </p-card>
 </div>

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
@@ -1,0 +1,45 @@
+<div class="contenedor-resumen">
+  <h2 class="titulo">Resumen Estadístico</h2>
+
+  <p *ngIf="!resumen || resumen.resultadosProcesados?.length === 0">
+    Cargando datos...
+  </p>
+
+  <div
+    *ngIf="(resumen?.resultadosProcesados?.length ?? 0) > 0"
+    class="bloque-estadisticas"
+  >
+    <h3>Cantidad de encuestados: {{ resumen.cantidadEncuestasProcesadas }}</h3>
+    <h3>Total de preguntas analizadas: {{ resumen.totalPreguntas }}</h3>
+    <h3>
+      Total de respuestas analizadas: {{ resumen.totalRespuestasAnalizadas }}
+    </h3>
+
+    <h4>Resultados por pregunta:</h4>
+    <div *ngFor="let resultado of resumen.resultadosProcesados ?? []">
+      <h3>{{ resultado.textoPregunta }}</h3>
+      <p>Tipo: {{ resultado.tipoPregunta }}</p>
+
+      <div *ngIf="(resultado.opciones?.length ?? 0) > 0">
+        <h4>Opciones seleccionadas:</h4>
+        <ul>
+          <li *ngFor="let opcion of resultado.opciones ?? []">
+            <strong>{{ opcion.textoOpcion }}</strong
+            >: {{ opcion.cantidadVecesSeleccionada }} veces ({{
+              opcion.porcentajeSeleccion
+            }})
+          </li>
+        </ul>
+      </div>
+
+      <div *ngIf="(resultado.respuestas?.length ?? 0) > 0">
+        <h4>Respuestas abiertas:</h4>
+        <ul>
+          <li *ngFor="let respuesta of resultado.respuestas ?? []">
+            {{ respuesta }}
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
@@ -17,6 +17,7 @@
             class="p-button-rounded p-button-success p-button-icon-only"
             (click)="descargarCSV()"
             title="Descargar estadísticas en CSV"
+            [disabled]="!resumen.resultadosProcesados?.length"
           >
             <i class="pi pi-download"></i>
           </button>
@@ -27,6 +28,7 @@
             class="p-button-rounded p-button-danger p-button-icon-only"
             (click)="descargarPDF()"
             title="Descargar estadísticas en PDF"
+            [disabled]="!resumen.resultadosProcesados?.length"
           >
             <i class="pi pi-download"></i>
           </button>

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.html
@@ -14,14 +14,12 @@
       class="bloque-estadisticas"
     >
       <!-- Botonera de navegación -->
-      <div
-        class="p-d-flex p-ai-center p-jc-center"
-        style="gap: 1rem; margin-bottom: 1.5rem"
-      >
+      <div class="p-d-flex p-ai-center p-jc-center botonera-navegacion">
         <button
           pButton
           icon="pi pi-angle-left"
           label="Anterior"
+          title="Anterior"
           (click)="anterior()"
           [disabled]="currentIndex() === 0"
           class="p-button-rounded p-button-secondary"
@@ -34,6 +32,7 @@
           pButton
           icon="pi pi-angle-right"
           label="Siguiente"
+          title="Siguiente"
           (click)="siguiente()"
           [disabled]="
             currentIndex() === resumen.resultadosProcesados.length - 1

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
@@ -72,7 +72,7 @@ export class ResumenEstadisticoComponent implements OnInit {
           this.currentIndex.set(0);
         },
         error: () => {
-          // Limpiar datos si hay error
+          // realizar limpieza para evitar datos inconsistentes
           this.resumen = {
             nombreEncuesta: '',
             cantidadEncuestasProcesadas: 0,

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResumenEstadisticoService } from '../../../services/resumen-estadistico.service';
+import { ResumenEstadisticoDTO } from '../../../models/resumen-estadistico.dto';
+import { MessageService } from 'primeng/api';
+
+@Component({
+  selector: 'app-resumen-estadistico',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './resumen-estadistico.component.html',
+  styleUrl: './resumen-estadistico.component.css',
+  providers: [MessageService],
+})
+export class ResumenEstadisticoComponent implements OnInit {
+  @Input() id!: number;
+  @Input() codigo!: string;
+  resumen: ResumenEstadisticoDTO = {
+    cantidadEncuestasProcesadas: 0,
+    totalPreguntas: 0,
+    totalRespuestasAnalizadas: 0,
+    resultadosProcesados: [],
+  }; // fix inicializo como objeto vacío
+
+  private resumenService = inject(ResumenEstadisticoService);
+  private messageService = inject(MessageService);
+
+  ngOnInit() {
+    this.obtenerResumen();
+  }
+
+  obtenerResumen() {
+    this.resumenService.obtenerResumen(this.id, this.codigo).subscribe({
+      /* next: (data: ResumenEstadisticoDTO) => {
+        console.log('Datos recibidos:', data);
+        this.resumen = data; // fix correcc. `undefined`
+      },*/
+
+      next: (data: any) => {
+        console.log('Datos recibidos:', data); // 🔥 Verifica que `resumenEstadistico` existe dentro de `data`
+        this.resumen = data.resumenEstadistico ?? {
+          cantidadEncuestasProcesadas: 0,
+          totalPreguntas: 0,
+          totalRespuestasAnalizadas: 0,
+          resultadosProcesados: [],
+        };
+      },
+
+      error: () => {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Error al obtener el resumen estadístico',
+        });
+      },
+    });
+  }
+}

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
@@ -27,7 +27,9 @@ import { ChartModule } from 'primeng/chart';
 export class ResumenEstadisticoComponent implements OnInit {
   @Input() id!: number;
   @Input() codigo!: string;
-  resumen: ResumenEstadisticoDTO = {
+
+  resumen: any = {
+    nombreEncuesta: '',
     cantidadEncuestasProcesadas: 0,
     totalPreguntas: 0,
     totalRespuestasAnalizadas: 0,
@@ -46,12 +48,24 @@ export class ResumenEstadisticoComponent implements OnInit {
   obtenerResumen() {
     this.resumenService.obtenerResumen(this.id, this.codigo).subscribe({
       next: (data: any) => {
-        this.resumen = data.resumenEstadistico ?? {
-          cantidadEncuestasProcesadas: 0,
-          totalPreguntas: 0,
-          totalRespuestasAnalizadas: 0,
-          resultadosProcesados: [],
-        };
+        // data puede traer nombreEncuesta a nivel raíz o dentro de resumenEstadistico
+        if (data.resumenEstadistico) {
+          this.resumen = {
+            ...data.resumenEstadistico,
+            nombreEncuesta:
+              data.nombreEncuesta ??
+              data.resumenEstadistico.nombreEncuesta ??
+              '',
+          };
+        } else {
+          this.resumen = {
+            nombreEncuesta: data.nombreEncuesta ?? '',
+            cantidadEncuestasProcesadas: 0,
+            totalPreguntas: 0,
+            totalRespuestasAnalizadas: 0,
+            resultadosProcesados: [],
+          };
+        }
         this.currentIndex.set(0);
       },
       error: () => {
@@ -66,12 +80,14 @@ export class ResumenEstadisticoComponent implements OnInit {
   anterior() {
     if (this.currentIndex() > 0) this.currentIndex.set(this.currentIndex() - 1);
   }
+
   siguiente() {
     if (
       this.currentIndex() <
       (this.resumen.resultadosProcesados?.length ?? 1) - 1
-    )
+    ) {
       this.currentIndex.set(this.currentIndex() + 1);
+    }
   }
 
   getPieChartData(resultado: any) {

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
@@ -72,6 +72,15 @@ export class ResumenEstadisticoComponent implements OnInit {
           this.currentIndex.set(0);
         },
         error: () => {
+          // Limpiar datos si hay error
+          this.resumen = {
+            nombreEncuesta: '',
+            cantidadEncuestasProcesadas: 0,
+            totalPreguntas: 0,
+            totalRespuestasAnalizadas: 0,
+            resultadosProcesados: [],
+          };
+          this.currentIndex.set(0);
           this.messageService.add({
             severity: 'error',
             summary: 'Error al obtener el resumen estadístico',

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.css
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.css
@@ -14,7 +14,7 @@
   font-size: 2rem;
   font-weight: bold;
   text-align: center;
-  margin: 20px 0;
+  margin: 20px 0 10px 0;
 }
 
 .botonera {
@@ -27,16 +27,18 @@
 .contenedor-visualizacion {
   width: clamp(300px, 80vw, 800px);
   padding: 2rem;
-  background-color: var(--color-background-light);
+  background-color: var(--color-background-light, #f4f8fb);
   border-radius: 12px;
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
 }
 
-p-button {
+p-button,
+button[pButton] {
   transition: transform 0.2s ease-in-out;
 }
 
-p-button:hover {
+p-button:hover,
+button[pButton]:hover {
   transform: scale(1.05);
 }
 
@@ -45,4 +47,19 @@ hr {
   height: 1px;
   background-color: #ccc;
   margin: 20px 0;
+}
+
+@media (max-width: 600px) {
+  .botonera {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .contenedor-visualizacion {
+    padding: 1rem;
+  }
+}
+
+.contenedor-visualizacion > * {
+  max-width: 100%;
+  box-sizing: border-box;
 }

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.css
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.css
@@ -3,63 +3,75 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: clamp(250px, 90vw, 800px);
+  width: clamp(250px, 90vw, 600px);
   overflow: auto;
   margin: 0 auto;
-  gap: 24px;
+  gap: 16px;
   color: black;
 }
 
+.contenedor-visualizacion {
+  width: clamp(250px, 95vw, 600px);
+  padding: 1rem;
+  background-color: var(--color-background-light, #f4f8fb);
+  border-radius: 10px;
+  box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.08);
+}
+
 .encuesta-titulo {
-  font-size: 2rem;
-  font-weight: bold;
+  font-size: 1.1rem;
+  font-weight: 600;
   text-align: center;
-  margin: 20px 0 10px 0;
+  margin: 10px 0 8px 0;
+  color: #1976d2;
+  letter-spacing: 0.01em;
 }
 
 .botonera {
   display: flex;
-  justify-content: space-around;
-  gap: 1rem;
-  margin-top: 1.5rem;
+  justify-content: center;
+  gap: 0.7rem;
+  margin-top: 0.7rem;
 }
 
-.contenedor-visualizacion {
-  width: clamp(300px, 80vw, 800px);
-  padding: 2rem;
-  background-color: var(--color-background-light, #f4f8fb);
-  border-radius: 12px;
-  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+.p-button {
+  border-radius: 8px !important;
+  font-size: 0.95rem !important;
+  padding: 0.3rem 1rem !important;
+  min-width: 0;
+  transition:
+    box-shadow 0.2s,
+    transform 0.2s;
 }
 
-p-button,
-button[pButton] {
-  transition: transform 0.2s ease-in-out;
+.blue-100 {
+  background-color: #dfebfb !important;
+  color: #1e40af !important;
+  border: none !important;
+  box-shadow: none !important;
 }
 
-p-button:hover,
-button[pButton]:hover {
-  transform: scale(1.05);
+.blue-700 {
+  background-color: #1d4ed8 !important;
+  color: #fff !important;
+  border: none !important;
+  box-shadow: 0 2px 8px rgba(29, 78, 216, 0.12);
+  transform: scale(1.04);
 }
 
-hr {
-  width: 100%;
-  height: 1px;
-  background-color: #ccc;
-  margin: 20px 0;
+.blue-100:hover,
+.blue-700:hover {
+  filter: brightness(0.97);
+  box-shadow: 0 2px 12px rgba(29, 78, 216, 0.18);
+  transform: scale(1.06);
 }
 
 @media (max-width: 600px) {
+  .contenedor-visualizacion {
+    padding: 0.5rem;
+  }
   .botonera {
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 0.4rem;
   }
-  .contenedor-visualizacion {
-    padding: 1rem;
-  }
-}
-
-.contenedor-visualizacion > * {
-  max-width: 100%;
-  box-sizing: border-box;
 }

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.css
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.css
@@ -1,0 +1,48 @@
+:host {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: clamp(250px, 90vw, 800px);
+  overflow: auto;
+  margin: 0 auto;
+  gap: 24px;
+  color: black;
+}
+
+.encuesta-titulo {
+  font-size: 2rem;
+  font-weight: bold;
+  text-align: center;
+  margin: 20px 0;
+}
+
+.botonera {
+  display: flex;
+  justify-content: space-around;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.contenedor-visualizacion {
+  width: clamp(300px, 80vw, 800px);
+  padding: 2rem;
+  background-color: var(--color-background-light);
+  border-radius: 12px;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+p-button {
+  transition: transform 0.2s ease-in-out;
+}
+
+p-button:hover {
+  transform: scale(1.05);
+}
+
+hr {
+  width: 100%;
+  height: 1px;
+  background-color: #ccc;
+  margin: 20px 0;
+}

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
@@ -12,6 +12,7 @@
       (click)="mostrarRespuestas()"
       [class.p-button-outlined]="mostrarVista !== 'respuestas'"
       [class.p-button-info]="mostrarVista === 'respuestas'"
+      title="Ver Respuestas"
     ></button>
 
     <button
@@ -22,6 +23,7 @@
       (click)="mostrarEstadisticas()"
       [class.p-button-outlined]="mostrarVista !== 'estadisticas'"
       [class.p-button-success]="mostrarVista === 'estadisticas'"
+      title="Ver Estadísticas"
     ></button>
   </div>
 

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
@@ -33,6 +33,7 @@
     <app-resultados-encuesta
       [codigo]="codigo"
       [id]="id"
+      [tipo]="tipo"
     ></app-resultados-encuesta>
   </div>
 
@@ -40,6 +41,7 @@
     <app-resumen-estadistico
       [codigo]="codigo"
       [id]="id"
+      [tipo]="tipo"
     ></app-resumen-estadistico>
   </div>
 </div>

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
@@ -1,0 +1,1 @@
+<p>visualizacion-resultados works!</p>

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
@@ -4,34 +4,38 @@
   <h1 class="encuesta-titulo">Resultados de la Encuesta</h1>
 
   <div class="botonera">
-    <p-button
+    <button
+      pButton
       label="Ver Respuestas"
       icon="pi pi-list"
-      severity="primary"
-      (click)="mostrarRespuestas()"
       [style]="{ width: '12rem', height: '3rem' }"
-    ></p-button>
+      (click)="mostrarRespuestas()"
+      [class.p-button-outlined]="mostrarVista !== 'respuestas'"
+      [class.p-button-info]="mostrarVista === 'respuestas'"
+    ></button>
 
-    <p-button
+    <button
+      pButton
       label="Ver Estadísticas"
       icon="pi pi-chart-bar"
-      severity="success"
-      (click)="mostrarEstadisticas()"
       [style]="{ width: '12rem', height: '3rem' }"
-    ></p-button>
+      (click)="mostrarEstadisticas()"
+      [class.p-button-outlined]="mostrarVista !== 'estadisticas'"
+      [class.p-button-success]="mostrarVista === 'estadisticas'"
+    ></button>
   </div>
 
   <div *ngIf="mostrarVista === 'respuestas'">
     <app-resultados-encuesta
-      [id]="id"
       [codigo]="codigo"
+      [id]="id"
     ></app-resultados-encuesta>
   </div>
 
   <div *ngIf="mostrarVista === 'estadisticas'">
     <app-resumen-estadistico
-      [id]="id"
       [codigo]="codigo"
+      [id]="id"
     ></app-resumen-estadistico>
   </div>
 </div>

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
@@ -1,17 +1,18 @@
 <p-toast></p-toast>
 
 <div class="contenedor-visualizacion">
-  <h1 class="encuesta-titulo">Resultados de la Encuesta</h1>
+  <h2 class="encuesta-titulo">Resultados de la Encuesta</h2>
 
   <div class="botonera">
     <button
       pButton
       label="Ver Respuestas"
       icon="pi pi-list"
-      [style]="{ width: '12rem', height: '3rem' }"
       (click)="mostrarRespuestas()"
-      [class.p-button-outlined]="mostrarVista !== 'respuestas'"
-      [class.p-button-info]="mostrarVista === 'respuestas'"
+      [ngClass]="{
+        'blue-700': mostrarVista === 'respuestas',
+        'blue-100': mostrarVista !== 'respuestas',
+      }"
       title="Ver Respuestas"
     ></button>
 
@@ -19,10 +20,11 @@
       pButton
       label="Ver Estadísticas"
       icon="pi pi-chart-bar"
-      [style]="{ width: '12rem', height: '3rem' }"
       (click)="mostrarEstadisticas()"
-      [class.p-button-outlined]="mostrarVista !== 'estadisticas'"
-      [class.p-button-success]="mostrarVista === 'estadisticas'"
+      [ngClass]="{
+        'blue-700': mostrarVista === 'estadisticas',
+        'blue-100': mostrarVista !== 'estadisticas',
+      }"
       title="Ver Estadísticas"
     ></button>
   </div>

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.html
@@ -1,1 +1,37 @@
-<p>visualizacion-resultados works!</p>
+<p-toast></p-toast>
+
+<div class="contenedor-visualizacion">
+  <h1 class="encuesta-titulo">Resultados de la Encuesta</h1>
+
+  <div class="botonera">
+    <p-button
+      label="Ver Respuestas"
+      icon="pi pi-list"
+      severity="primary"
+      (click)="mostrarRespuestas()"
+      [style]="{ width: '12rem', height: '3rem' }"
+    ></p-button>
+
+    <p-button
+      label="Ver Estadísticas"
+      icon="pi pi-chart-bar"
+      severity="success"
+      (click)="mostrarEstadisticas()"
+      [style]="{ width: '12rem', height: '3rem' }"
+    ></p-button>
+  </div>
+
+  <div *ngIf="mostrarVista === 'respuestas'">
+    <app-resultados-encuesta
+      [id]="id"
+      [codigo]="codigo"
+    ></app-resultados-encuesta>
+  </div>
+
+  <div *ngIf="mostrarVista === 'estadisticas'">
+    <app-resumen-estadistico
+      [id]="id"
+      [codigo]="codigo"
+    ></app-resumen-estadistico>
+  </div>
+</div>

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-visualizacion-resultados',
+  imports: [],
+  templateUrl: './visualizacion-resultados.component.html',
+  styleUrl: './visualizacion-resultados.component.css'
+})
+export class VisualizacionResultadosComponent {
+
+}

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
@@ -22,7 +22,7 @@ import { ResumenEstadisticoComponent } from '../resumen-estadistico/resumen-esta
   providers: [MessageService],
 })
 export class VisualizacionResultadosComponent implements OnInit {
-  mostrarVista: 'respuestas' | 'estadisticas' | null = 'respuestas';
+  mostrarVista: 'respuestas' | 'estadisticas' = 'respuestas';
   id!: number;
   codigo!: string;
 
@@ -35,9 +35,6 @@ export class VisualizacionResultadosComponent implements OnInit {
   obtenerParametros() {
     this.id = Number(this.route.snapshot.paramMap.get('id')) || 0;
     this.codigo = this.route.snapshot.queryParamMap.get('codigo') ?? '';
-
-    console.log('ID:', this.id);
-    console.log('Código:', this.codigo);
   }
 
   mostrarRespuestas() {

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
@@ -1,11 +1,50 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { CommonModule } from '@angular/common';
+import { ButtonModule } from 'primeng/button';
+import { ToastModule } from 'primeng/toast';
+import { MessageService } from 'primeng/api';
+import { ResultadosEncuestaComponent } from '../resultados-encuesta/resultados-encuesta.component';
+import { ResumenEstadisticoComponent } from '../resumen-estadistico/resumen-estadistico.component';
 
 @Component({
   selector: 'app-visualizacion-resultados',
-  imports: [],
+  standalone: true,
+  imports: [
+    CommonModule,
+    ButtonModule,
+    ToastModule,
+    ResultadosEncuestaComponent,
+    ResumenEstadisticoComponent,
+  ],
   templateUrl: './visualizacion-resultados.component.html',
-  styleUrl: './visualizacion-resultados.component.css'
+  styleUrl: './visualizacion-resultados.component.css',
+  providers: [MessageService],
 })
-export class VisualizacionResultadosComponent {
+export class VisualizacionResultadosComponent implements OnInit {
+  mostrarVista: 'respuestas' | 'estadisticas' | null = 'respuestas';
+  id!: number;
+  codigo!: string;
 
+  private route = inject(ActivatedRoute);
+
+  ngOnInit() {
+    this.obtenerParametros();
+  }
+
+  obtenerParametros() {
+    this.id = Number(this.route.snapshot.paramMap.get('id')) || 0;
+    this.codigo = this.route.snapshot.queryParamMap.get('codigo') ?? '';
+
+    console.log('ID:', this.id);
+    console.log('Código:', this.codigo);
+  }
+
+  mostrarRespuestas() {
+    this.mostrarVista = 'respuestas';
+  }
+
+  mostrarEstadisticas() {
+    this.mostrarVista = 'estadisticas';
+  }
 }

--- a/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
+++ b/frontend/src/app/components/resultados/visualizacion-resultados/visualizacion-resultados.component.ts
@@ -25,7 +25,7 @@ export class VisualizacionResultadosComponent implements OnInit {
   mostrarVista: 'respuestas' | 'estadisticas' = 'respuestas';
   id!: number;
   codigo!: string;
-
+  tipo!: string;
   private route = inject(ActivatedRoute);
 
   ngOnInit() {
@@ -35,6 +35,7 @@ export class VisualizacionResultadosComponent implements OnInit {
   obtenerParametros() {
     this.id = Number(this.route.snapshot.paramMap.get('id')) || 0;
     this.codigo = this.route.snapshot.queryParamMap.get('codigo') ?? '';
+    this.tipo = this.route.snapshot.queryParamMap.get('tipo') ?? '';
   }
 
   mostrarRespuestas() {

--- a/frontend/src/app/models/resultados-encuesta.dto.ts
+++ b/frontend/src/app/models/resultados-encuesta.dto.ts
@@ -1,0 +1,14 @@
+export interface RespuestaEncuestaDTO {
+  encuestado: string;
+  respuestasOpciones: {
+    idPregunta: number;
+    textoPregunta: string;
+    opcionSeleccionada: string;
+  }[];
+  respuestasAbiertas: {
+    idPregunta: number;
+    textoPregunta: string;
+    textoRespuesta: string;
+  }[];
+}
+//dto para el resultado de una encuesta con todas las respuestas

--- a/frontend/src/app/models/resumen-estadistico.dto.ts
+++ b/frontend/src/app/models/resumen-estadistico.dto.ts
@@ -1,0 +1,15 @@
+export interface ResumenEstadisticoDTO {
+  cantidadEncuestasProcesadas: number;
+  totalPreguntas: number;
+  totalRespuestasAnalizadas: number;
+  resultadosProcesados: {
+    textoPregunta: string;
+    tipoPregunta: string;
+    opciones?: {
+      textoOpcion: string;
+      cantidadVecesSeleccionada: number;
+      porcentajeSeleccion: string;
+    }[];
+    respuestas?: string[];
+  }[];
+}

--- a/frontend/src/app/models/resumen-estadistico.dto.ts
+++ b/frontend/src/app/models/resumen-estadistico.dto.ts
@@ -1,4 +1,5 @@
 export interface ResumenEstadisticoDTO {
+  nombreEncuesta?: string; // <-- AGREGADO
   cantidadEncuestasProcesadas: number;
   totalPreguntas: number;
   totalRespuestasAnalizadas: number;
@@ -10,6 +11,7 @@ export interface ResumenEstadisticoDTO {
       cantidadVecesSeleccionada: number;
       porcentajeSeleccion: string;
     }[];
+    totalRespuestas?: number; // <-- AGREGADO para preguntas abiertas
     respuestas?: string[];
   }[];
 }

--- a/frontend/src/app/services/descarga.service.ts
+++ b/frontend/src/app/services/descarga.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class DescargaService {
+  constructor(private http: HttpClient) {}
+
+  descargarArchivo(url: string): Observable<Blob> {
+    return this.http.get(url, { responseType: 'blob' });
+  }
+}
+//servicio para descargar archivos, como CSV o PDF, desde el backend
+// Este servicio utiliza HttpClient para realizar una solicitud GET a la URL proporcionada
+// y espera recibir un Blob como respuesta, que representa el archivo descargado.

--- a/frontend/src/app/services/resultados.service.ts
+++ b/frontend/src/app/services/resultados.service.ts
@@ -1,0 +1,20 @@
+import { inject, Injectable } from '@angular/core';
+import { RequestService } from './request.service';
+import { Observable } from 'rxjs';
+import { RespuestaEncuestaDTO } from '../models/resultados-encuesta.dto';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ResultadosService {
+  private readonly _requestService = inject(RequestService);
+
+  getResultados(
+    idEncuesta: number,
+    codigo: string,
+  ): Observable<RespuestaEncuestaDTO[]> {
+    return this._requestService.get<RespuestaEncuestaDTO[]>(
+      `/encuestas/${idEncuesta}?codigo=${codigo}&tipo=RESULTADOS`,
+    );
+  }
+}

--- a/frontend/src/app/services/resultados.service.ts
+++ b/frontend/src/app/services/resultados.service.ts
@@ -12,9 +12,10 @@ export class ResultadosService {
   getResultados(
     idEncuesta: number,
     codigo: string,
+    tipo: string,
   ): Observable<RespuestaEncuestaDTO[]> {
     return this._requestService.get<RespuestaEncuestaDTO[]>(
-      `/encuestas/${idEncuesta}?codigo=${codigo}&tipo=RESULTADOS`,
+      `/encuestas/${idEncuesta}?codigo=${codigo}&tipo=${tipo}`,
     );
   }
 }

--- a/frontend/src/app/services/resumen-estadistico.service.ts
+++ b/frontend/src/app/services/resumen-estadistico.service.ts
@@ -1,0 +1,20 @@
+import { inject, Injectable } from '@angular/core';
+import { RequestService } from './request.service';
+import { Observable } from 'rxjs';
+import { ResumenEstadisticoDTO } from '../models/resumen-estadistico.dto';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ResumenEstadisticoService {
+  private readonly _requestService = inject(RequestService);
+
+  obtenerResumen(
+    idEncuesta: number,
+    codigo: string,
+  ): Observable<ResumenEstadisticoDTO> {
+    return this._requestService.get<ResumenEstadisticoDTO>(
+      `/reportes/${idEncuesta}/${codigo}`,
+    );
+  }
+}

--- a/frontend/src/app/services/resumen-estadistico.service.ts
+++ b/frontend/src/app/services/resumen-estadistico.service.ts
@@ -12,9 +12,10 @@ export class ResumenEstadisticoService {
   obtenerResumen(
     idEncuesta: number,
     codigo: string,
+    tipo: string,
   ): Observable<ResumenEstadisticoDTO> {
     return this._requestService.get<ResumenEstadisticoDTO>(
-      `/reportes/${idEncuesta}/${codigo}`,
+      `/reportes/${idEncuesta}/${codigo}?tipo=${tipo}`,
     );
   }
 }


### PR DESCRIPTION
resultados front cumple con funcionalidad requerida de mostrar las respuestas de una encuesta pero agrega a resultados además una vista de las estadísticas de esa encuesta seleccionada. Otra funcionalidad adicional es la descarga del contenido de ambas vistas en pdf y csv. Se modificó para validar el enlace que permite ver resultados fragmentos de código en endpoints de la api que sirven a estos componentes del front. Se agregó un acceso a la homepage para acceder a estos resultados con su respectiva validación.