### PR TITLE
Exper usuario/descargas pdf csv

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4792,12 +4792,6 @@
       "integrity": "sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==",
       "license": "MIT"
     },
-    "node_modules/@streamparser/json": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@streamparser/json/-/json-0.0.6.tgz",
-      "integrity": "sha512-vL9EVn/v+OhZ+Wcs6O4iKE9EUpwHUqHmCtNUMWjqp+6dr85+XPOSGTEsqYNq1Vn04uk9SWlOVmx9J48ggJVT2Q==",
-      "license": "MIT"
-    },
     "node_modules/@swc/cli": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.6.0.tgz",
@@ -12056,33 +12050,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json2csv": {
-      "version": "6.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-6.0.0-alpha.2.tgz",
-      "integrity": "sha512-nJ3oP6QxN8z69IT1HmrJdfVxhU1kLTBVgMfRnNZc37YEY+jZ4nU27rBGxT4vaqM/KUCavLRhntmTuBFqZLBUcA==",
-      "license": "MIT",
-      "dependencies": {
-        "@streamparser/json": "^0.0.6",
-        "commander": "^6.2.0",
-        "lodash.get": "^4.4.2"
-      },
-      "bin": {
-        "json2csv": "bin/json2csv.js"
-      },
-      "engines": {
-        "node": ">= 12",
-        "npm": ">= 6.13.0"
-      }
-    },
-    "node_modules/json2csv/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -12346,13 +12313,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.html
@@ -36,12 +36,10 @@
       </div>
     </ng-template>
 
-    <!-- Mensaje de carga -->
     <p *ngIf="cargando" class="cargando">
       Cargando datos... No te desesperes, no es la fila del banco!
     </p>
 
-    <!-- Mensaje si no hay respuestas y no está cargando ni hay error -->
     <p
       *ngIf="!cargando && !respuestas.length && !errorCarga"
       class="cargando"
@@ -51,7 +49,6 @@
       solo la pensaste?
     </p>
 
-    <!-- Mensaje de error -->
     <p *ngIf="errorCarga" class="cargando" style="color: #d32f2f">
       No existen encuestas con el enlace de acceso cargado.
     </p>

--- a/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
+++ b/frontend/src/app/components/resultados/resultados-encuesta/resultados-encuesta.component.ts
@@ -30,14 +30,14 @@ export class ResultadosEncuestaComponent implements OnInit {
   private messageService = inject(MessageService);
 
   errorCarga = false;
-  cargando = true; // <-- agregada
+  cargando = true;
 
   ngOnInit() {
     this.obtenerResultados();
   }
 
   obtenerResultados() {
-    this.cargando = true; // <-- agregada
+    this.cargando = true;
     this.errorCarga = false;
     this.resultadosService
       .getResultados(this.id, this.codigo, this.tipo)
@@ -49,7 +49,7 @@ export class ResultadosEncuestaComponent implements OnInit {
             : [];
           this.currentIndex.set(0);
           this.errorCarga = false;
-          this.cargando = false; // <-- agregada
+          this.cargando = false;
           if (!this.respuestas.length) {
             this.messageService.add({
               severity: 'warn',
@@ -61,7 +61,7 @@ export class ResultadosEncuestaComponent implements OnInit {
         error: () => {
           this.respuestas = [];
           this.errorCarga = true;
-          this.cargando = false; // <-- agregada
+          this.cargando = false;
           this.messageService.add({
             severity: 'error',
             summary: 'Error al obtener resultados',
@@ -71,6 +71,11 @@ export class ResultadosEncuestaComponent implements OnInit {
   }
 
   descargarCSV() {
+    this.messageService.add({
+      severity: 'info',
+      summary: 'Descarga',
+      detail: 'Comenzó la descarga del CSV',
+    });
     const url = `/api/v1/encuestas/csv/${this.id}/${this.codigo}`;
     this.descargaService.descargarArchivo(url).subscribe((blob) => {
       this.descargarBlob(blob, 'resultados-encuesta.csv');
@@ -78,6 +83,11 @@ export class ResultadosEncuestaComponent implements OnInit {
   }
 
   descargarPDF() {
+    this.messageService.add({
+      severity: 'info',
+      summary: 'Descarga',
+      detail: 'Comenzó la descarga del PDF',
+    });
     const url = `/api/v1/encuestas/pdf/${this.id}/${this.codigo}`;
     this.descargaService.descargarArchivo(url).subscribe((blob) => {
       this.descargarBlob(blob, 'resultados-encuesta.pdf');

--- a/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
+++ b/frontend/src/app/components/resultados/resumen-estadistico/resumen-estadistico.component.ts
@@ -29,7 +29,6 @@ export class ResumenEstadisticoComponent implements OnInit {
   @Input() codigo!: string;
   @Input() tipo!: string;
 
-  // Inicialización más robusta para evitar undefined
   resumen: any = {
     nombreEncuesta: '',
     cantidadEncuestasProcesadas: 0,
@@ -40,7 +39,7 @@ export class ResumenEstadisticoComponent implements OnInit {
 
   currentIndex = signal(0);
   errorCarga = false;
-  cargando = true; // El estado inicial debe ser cargando
+  cargando = true;
 
   private resumenService = inject(ResumenEstadisticoService);
   private messageService = inject(MessageService);
@@ -51,13 +50,12 @@ export class ResumenEstadisticoComponent implements OnInit {
   }
 
   obtenerResumen() {
-    this.cargando = true; // Siempre inicia cargando al pedir datos
-    this.errorCarga = false; // Resetea el estado de error
+    this.cargando = true;
+    this.errorCarga = false;
     this.resumenService
       .obtenerResumen(this.id, this.codigo, this.tipo)
       .subscribe({
         next: (data: any) => {
-          // Si hay resumenEstadistico, úsalo, sino inicializa limpio
           if (data && data.resumenEstadistico) {
             this.resumen = {
               ...data.resumenEstadistico,
@@ -67,19 +65,17 @@ export class ResumenEstadisticoComponent implements OnInit {
                 '',
             };
           } else {
-            // Si no hay resumenEstadistico, inicializa con valores por defecto
             this.resumen = {
-              nombreEncuesta: data?.nombreEncuesta ?? '', // Asegura que el nombre de la encuesta se propague si existe
+              nombreEncuesta: data?.nombreEncuesta ?? '',
               cantidadEncuestasProcesadas: 0,
               totalPreguntas: 0,
               totalRespuestasAnalizadas: 0,
               resultadosProcesados: [],
             };
           }
-          this.currentIndex.set(0); // Reinicia el índice al cargar nuevos datos
-          this.cargando = false; // Finaliza la carga
+          this.currentIndex.set(0);
+          this.cargando = false;
 
-          // Mensaje de advertencia si no hay encuestas procesadas
           if (this.resumen.cantidadEncuestasProcesadas === 0) {
             this.messageService.add({
               severity: 'warn',
@@ -89,7 +85,6 @@ export class ResumenEstadisticoComponent implements OnInit {
           }
         },
         error: () => {
-          // En caso de error, resetea el resumen y marca el error
           this.resumen = {
             nombreEncuesta: '',
             cantidadEncuestasProcesadas: 0,
@@ -109,8 +104,13 @@ export class ResumenEstadisticoComponent implements OnInit {
       });
   }
 
-  // Métodos de descarga (sin cambios en la lógica interna, solo la deshabilitación)
   descargarPDF() {
+    this.messageService.add({
+      severity: 'info',
+      summary: 'Descarga',
+      detail: 'Comenzó la descarga del PDF',
+    });
+
     const url = `/api/v1/reportes/pdf/${this.id}/${this.codigo}?tipo=${this.tipo}`;
     this.http.get(url, { responseType: 'blob' }).subscribe({
       next: (blob) => {
@@ -131,6 +131,12 @@ export class ResumenEstadisticoComponent implements OnInit {
   }
 
   descargarCSV() {
+    this.messageService.add({
+      severity: 'info',
+      summary: 'Descarga',
+      detail: 'Comenzó la descarga del CSV',
+    });
+
     const url = `/api/v1/reportes/csv/${this.id}/${this.codigo}?tipo=${this.tipo}`;
     this.http.get(url, { responseType: 'blob' }).subscribe({
       next: (blob) => {
@@ -157,7 +163,7 @@ export class ResumenEstadisticoComponent implements OnInit {
   siguiente() {
     if (
       this.currentIndex() <
-      (this.resumen.resultadosProcesados?.length ?? 0) - 1 // Usar 0 en lugar de 1 si es null/undefined
+      (this.resumen.resultadosProcesados?.length ?? 0) - 1
     ) {
       this.currentIndex.set(this.currentIndex() + 1);
     }


### PR DESCRIPTION
Se agrega mejora de notificaciones de inicio de descarga para una mejor experiencia de usuario, al iniciar descargas de pdf y csv. Esto es útil sobre todo para el caso presencia de gráficos estadísticos, donde se había aumentado anteriormente el tiempo de espera para el correcto renderizado de los mismos.